### PR TITLE
Transclude improvements

### DIFF
--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -310,6 +310,7 @@ export class SyncerPageCompiler {
 			for (const transclusionMatch of transclusionMatches ?? []) {
 				try {
 					const [transclusionFileName, headerName] = transclusionMatch
+						.replaceAll("\\|", "|")
 						.substring(
 							transclusionMatch.indexOf("[") + 2,
 							transclusionMatch.indexOf("]"),
@@ -601,6 +602,7 @@ export class SyncerPageCompiler {
 					const imageMatch = transcludedImageMatches[i];
 
 					const [imageName, _] = imageMatch
+						.replaceAll("\\|", "|")
 						.substring(
 							imageMatch.indexOf("[") + 2,
 							imageMatch.indexOf("]"),
@@ -686,6 +688,7 @@ export class SyncerPageCompiler {
 						//Alt 2: [image.png|meta1 meta2|100]
 						//Alt 3: [image.png|meta1 meta2]
 						const [imageName, ...metaDataAndSize] = imageMatch
+							.replaceAll("\\|", "|")
 							.substring(
 								imageMatch.indexOf("[") + 2,
 								imageMatch.indexOf("]"),

--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -27,6 +27,8 @@ import {
 	BLOCKREF_REGEX,
 	TRANSCLUDED_SVG_REGEX,
 	DATAVIEW_LINK_TARGET_BLANK_REGEX,
+	IMAGE_REGEX,
+	TRANSCLUDED_IMAGE_REGEX,
 } from "../utils/regexes";
 import Logger from "js-logger";
 import { DataviewCompiler } from "./DataviewCompiler";
@@ -591,9 +593,7 @@ export class SyncerPageCompiler {
 		const assets = [];
 
 		//![[image.png]]
-		const transcludedImageRegex =
-			/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\]\]/g;
-		const transcludedImageMatches = text.match(transcludedImageRegex);
+		const transcludedImageMatches = text.match(TRANSCLUDED_IMAGE_REGEX);
 
 		if (transcludedImageMatches) {
 			for (let i = 0; i < transcludedImageMatches.length; i++) {
@@ -628,8 +628,7 @@ export class SyncerPageCompiler {
 		}
 
 		//![](image.png)
-		const imageRegex = /!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp))\)/g;
-		const imageMatches = text.match(imageRegex);
+		const imageMatches = text.match(IMAGE_REGEX);
 
 		if (imageMatches) {
 			for (let i = 0; i < imageMatches.length; i++) {
@@ -676,9 +675,7 @@ export class SyncerPageCompiler {
 			let imageText = text;
 
 			//![[image.png]]
-			const transcludedImageRegex =
-				/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\]\]/g;
-			const transcludedImageMatches = text.match(transcludedImageRegex);
+			const transcludedImageMatches = text.match(TRANSCLUDED_IMAGE_REGEX);
 
 			if (transcludedImageMatches) {
 				for (let i = 0; i < transcludedImageMatches.length; i++) {
@@ -779,9 +776,7 @@ export class SyncerPageCompiler {
 			}
 
 			//![](image.png)
-			const imageRegex =
-				/!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp))\)/g;
-			const imageMatches = text.match(imageRegex);
+			const imageMatches = text.match(IMAGE_REGEX);
 
 			if (imageMatches) {
 				for (let i = 0; i < imageMatches.length; i++) {

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -13,7 +13,8 @@ export const TRANSCLUDED_SVG_REGEX =
 export const DATAVIEW_LINK_TARGET_BLANK_REGEX =
 	/target=["']_blank["'] rel=["']noopener["']/g;
 
-export const IMAGE_REGEX = /!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp))\)/g;
+export const IMAGE_REGEX =
+	/!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\)/g;
 
 export const TRANSCLUDED_IMAGE_REGEX =
-	/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\]\]/g;
+	/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\]\]/g;

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -17,4 +17,4 @@ export const IMAGE_REGEX =
 	/!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\)/g;
 
 export const TRANSCLUDED_IMAGE_REGEX =
-	/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\]\]/g;
+	/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\\?\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp|bmp))\]\]/g;

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -12,3 +12,8 @@ export const TRANSCLUDED_SVG_REGEX =
 
 export const DATAVIEW_LINK_TARGET_BLANK_REGEX =
 	/target=["']_blank["'] rel=["']noopener["']/g;
+
+export const IMAGE_REGEX = /!\[(.*?)\]\((.*?)(\.(png|jpg|jpeg|gif|webp))\)/g;
+
+export const TRANSCLUDED_IMAGE_REGEX =
+	/!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\|(.*?)\]\]|!\[\[(.*?)(\.(png|jpg|jpeg|gif|webp))\]\]/g;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"importHelpers": true,
 		"esModuleInterop": true,
 		"verbatimModuleSyntax": false,
-		"lib": ["DOM", "ES5", "ES6", "ES7"],
+		"lib": ["DOM", "ES5", "ES6", "ES7", "ES2021.String"],
 		"types": ["svelte", "node", "jest"]
 	},
 	"include": ["**/*.ts", "**/*.js", "**/*.svelte"]


### PR DESCRIPTION
This PR does three things.

1. Move the transcluded image regexs into the regexes file and import it, reducing duplicate code
2. add bmps to the list of transcluded images
3. improve the transcluded images regex to account for images in tables that have an escaped pipe

**Things to note:** svgs are handled in a separate step than other images and I haven't looked at them yet. There's a good chance that svgs embeded in tables with custom data after the pipe don't work, but I haven't investigated that yet