### PR TITLE
fix: full link path replacement applied section by section rather than full file

### DIFF
--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -280,6 +280,7 @@ export class SyncerPageCompiler {
 			CODE_FENCE_REGEX,
 		];
 
+		// Create one large regex pattern which matches every skip pattern
 		const allSkipPatterns = new RegExp(
 			`(${skipPatterns.map((pattern) => pattern.source).join("|")})`,
 			"g",
@@ -289,6 +290,8 @@ export class SyncerPageCompiler {
 		let index = 0;
 		let sectionMatch;
 
+		// Parse the entire text and separate it into sections of text matching
+		// skip patterns and the remaining text in between
 		while ((sectionMatch = allSkipPatterns.exec(text)) !== null) {
 			sections.push(text.substring(index, sectionMatch.index));
 
@@ -299,6 +302,7 @@ export class SyncerPageCompiler {
 		}
 		sections.push(text.substring(index));
 
+		// Skip sections that match a skip pattern and apply the link conversion to the others
 		const modifiedSections = await Promise.all(
 			sections.map(async (section) => {
 				if (skipPatterns.some((pattern) => pattern.test(section))) {

--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -276,7 +276,7 @@ export class SyncerPageCompiler {
 		const skipPatterns = [
 			FRONTMATTER_REGEX,
 			EXCALIDRAW_REGEX,
-			CODE_FENCE_REGEX,
+			CODEBLOCK_REGEX,
 			CODE_FENCE_REGEX,
 		];
 
@@ -290,8 +290,7 @@ export class SyncerPageCompiler {
 		let index = 0;
 		let sectionMatch;
 
-		// Parse the entire text and separate it into sections of text matching
-		// skip patterns and the remaining text in between
+		// Parse the entire text and separate it into sections of text matching skip patterns and the remaining text in between
 		while ((sectionMatch = allSkipPatterns.exec(text)) !== null) {
 			sections.push(text.substring(index, sectionMatch.index));
 
@@ -302,7 +301,8 @@ export class SyncerPageCompiler {
 		}
 		sections.push(text.substring(index));
 
-		// Skip sections that match a skip pattern and apply the link conversion to the others
+		// Skip sections that match a skip pattern and apply the link conversion to the remaining
+		// This ensures no wikilinks within skipped sections (like frontmatter) get parsed
 		const modifiedSections = await Promise.all(
 			sections.map(async (section) => {
 				if (skipPatterns.some((pattern) => pattern.test(section))) {


### PR DESCRIPTION
This fixes an error that occurs if a wikilink appears both in the frontmatter and in the main body of a note.

Previous implementation had the regex search the body of the text, but apply the replacement to the entire note. If there existed a `[[wikilink]]` in the frontmatter that was formatted exactly the same as a `[[wikilink]]` in the main body, then the link in the frontmatter would be the one replaced when `regex.replace()` was called.

My solution is as follows:  

1. Using regex.exec find the borders of all sections which have to be skipped (frontmatter, code fences, code blocks, excalidraw)
2. Break the text into an array of skippable sections and all other text
3. Apply the wikilink replacement individually to each section not skipped

***

This could potentially be refactored to do the conversion while splitting, but I did it this way to take advantage of asynchronous map 