### PR TITLE
Fix code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -318,6 +318,7 @@ export class RepositoryConnection {
 
 		const normalizePath = (path: string) => {
 			let previous;
+
 			do {
 				previous = path;
 				path = path.replace(/\.\.\//g, "");

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -317,7 +317,11 @@ export class RepositoryConnection {
 		const baseTreeSha = latestCommit.commit.tree.sha;
 
 		const normalizePath = (path: string) => {
-			path = path.replace(/\.\.\//g, "");
+			let previous;
+			do {
+				previous = path;
+				path = path.replace(/\.\.\//g, "");
+			} while (path !== previous);
 
 			return path.startsWith("/")
 				? `${this.contentFolder}${path}`


### PR DESCRIPTION
Fixes [https://github.com/saberzero1/quartz-syncer/security/code-scanning/6](https://github.com/saberzero1/quartz-syncer/security/code-scanning/6)

To fix the problem, we need to ensure that all instances of `../` are removed from the path, not just the first occurrence. This can be achieved by repeatedly applying the regular expression replacement until no more replacements can be performed. This approach ensures that any remaining `../` sequences are fully removed, mitigating the risk of path traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
