### PR TITLE
Add embed container

### DIFF
--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -300,12 +300,13 @@ export class SyncerPageCompiler {
 
 			for (const transclusionMatch of transclusionMatches ?? []) {
 				try {
-					const [transclusionFileNameInitial, _] = transclusionMatch
-						.substring(
-							transclusionMatch.indexOf("[") + 2,
-							transclusionMatch.indexOf("]"),
-						)
-						.split("|");
+					const [transclusionFileNameInitial, transclusionAlias] =
+						transclusionMatch
+							.substring(
+								transclusionMatch.indexOf("[") + 2,
+								transclusionMatch.indexOf("]"),
+							)
+							.split("|");
 
 					const transclusionFileName =
 						transclusionFileNameInitial.endsWith("\\")
@@ -473,7 +474,7 @@ export class SyncerPageCompiler {
 						//This should be recursive up to a certain depth
 						transcludedText = transcludedText.replace(
 							transclusionMatch,
-							fileText,
+							`<div class="transclude" data-embed-alias=" ${transclusionAlias ? transclusionAlias.trim() : ""} " data-url="${linkedFile.path.replace(/\.md$/, "")}"> \n\n${fileText}\n\n</div>\n <a href="${linkedFile.path.replace(/\.md$/, "")}" class="internal transclude-src">Link to original</a>`,
 						);
 					}
 				} catch (error) {


### PR DESCRIPTION
Added a parent `<div>` to the transclusion and included a link to the original file, matching the transclusion behavior of Quartz. This enables users to apply custom CSS and other customizations to the transclusion. I am not familiar with the naming conventions and slugification, so please modify as necessary.