### PR TITLE
fix: block math transclusion

### DIFF
--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -461,6 +461,12 @@ export class SyncerPageCompiler {
 							}
 						}
 
+						// Fixing malformed block math transclusions:
+						fileText = fileText.replace(
+							/(^|[^$])\$\$($)/gm, // only match double dollar signs (block math)
+							"$1$$$$$$$$$2", // adding two extra dollar signs
+						);
+
 						if (fileText.match(transcludedRegex)) {
 							fileText = await this.createTranscludedText(
 								currentDepth + 1,
@@ -478,31 +484,6 @@ export class SyncerPageCompiler {
 					continue;
 				}
 			}
-
-			// Fix MathJax transclusions
-			// double dollar signs tend to collapse into a single one which makes them inlined
-			// this is a workaround to fix that
-			/*
-			example:
-			$$
-			hello
-			$$
-			turns into
-			$
-			hello
-			$
-			which is not what we want
-			we do want to keep inlined math as it is, so we only fix the ones that should not be inlined:
-			$goodbye$ //good
-			$
-			hello
-			$ //bad
-			*/
-			// Fixing malformed transclusions:
-			transcludedText = transcludedText.replace(
-				/(^|[^$])\$($)/gm,
-				"$1$$$$$2",
-			);
 
 			return transcludedText;
 		};

--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -461,17 +461,17 @@ export class SyncerPageCompiler {
 							}
 						}
 
-						// Fixing malformed block math transclusions:
-						fileText = fileText.replace(
-							/(^|[^$])\$\$($)/gm, // only match double dollar signs (block math)
-							"$1$$$$$$$$$2", // adding two extra dollar signs
-						);
-
 						if (fileText.match(transcludedRegex)) {
 							fileText = await this.createTranscludedText(
 								currentDepth + 1,
 							)(publishLinkedFile)(fileText);
 						}
+
+						// Fixing malformed block math transclusions:
+						fileText = fileText.replace(
+							/(^|[^$])\$\$($)/gm, // only match double dollar signs (block math)
+							"$1$$$$$$$$$2", // adding two extra dollar signs
+						);
 
 						//This should be recursive up to a certain depth
 						transcludedText = transcludedText.replace(


### PR DESCRIPTION
Hi! Thanks for the quick fix! However, I spotted two issues:

1. The regex matches inline math as well. Suppose I have the following line in my file:
    ```markdown
    This is a line with some inline math at the end $f(x)=y$
    ```
    The fix transforms it into
    ```markdown
    This is a line with some inline math at the end $f(x)=y$$
    ```
2. The fix does not only apply to transcluded content `fileText` but also to the whole file `transcludedText`, which may not be necessasry.

The proposed solution to the above two issues is to add two extra dollar signs to the existing double-dollar sign (which no longer matches inline math), and only apply this transformation to the transcluded content.