### PR TITLE
Fix small typo in docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ aliases: [home]
 
 [Quartz Syncer](https://github.com/saberzero1/quartz-syncer) is an [Obsidian](https://obsidian.md/) plugin for managing and publishing notes to [Quartz](https://quartz.jzhao.xyz/), the fast, batteries-included static-site generator that transforms Markdown content into fully functional websites.
 
-Quartz Syncer fully utilizes the capabilities of Obsidian to enable features that would otherwise be hard or impossible to replicate in Quartz, like [[Settings/Integrations/index|integrating Obsidian plugins]], such as [[Settings/Integrations/Dataview|Dataview]], [[Settings/Integrations/Datacore|Datacore]], and [[Fantasy Statblocks]], precompiling [[Apply embeds|embeddings]], or [[Configuring a specific folder for Quartz content|using a specific folder for Quartz content, instead of the entire vautl]].
+Quartz Syncer fully utilizes the capabilities of Obsidian to enable features that would otherwise be hard or impossible to replicate in Quartz, like [[Settings/Integrations/index|integrating Obsidian plugins]], such as [[Settings/Integrations/Dataview|Dataview]], [[Settings/Integrations/Datacore|Datacore]], and [[Fantasy Statblocks]], precompiling [[Apply embeds|embeddings]], or [[Configuring a specific folder for Quartz content|using a specific folder for Quartz content, instead of the entire vault]].
 
 ## Installation
 


### PR DESCRIPTION
silly little PR

`vautl` -> `vault`