### PR TITLE
fix: Respect vault path setting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
 	preset: "ts-jest/presets/js-with-ts",
 	testEnvironment: "node",
+	moduleNameMapper: {
+		"^src/(.*)$": "<rootDir>/src/$1",
+	},
 };

--- a/src/publisher/Publisher.test.ts
+++ b/src/publisher/Publisher.test.ts
@@ -1,0 +1,96 @@
+import Publisher from "./Publisher";
+import QuartzSyncer from "main";
+
+import { TFile, Vault, MetadataCache, App } from "obsidian";
+import QuartzSyncerSettings from "src/models/settings";
+import { DataStore } from "src/publishFile/DataStore";
+
+jest.mock("src/publishFile/PublishFile", () => {
+	return {
+		PublishFile: jest.fn(({ file }) => ({
+			file,
+			getBlobLinks: jest.fn().mockResolvedValue([]),
+			compare: (other: TFile) => file.path.localeCompare(other.path),
+		})),
+	};
+});
+
+describe("Publisher", () => {
+	describe("getFilesMarkedForPublishing", () => {
+		let publisher: Publisher;
+
+		const vaultFiles = Object.freeze([
+			"note1.md",
+			"note2.md",
+			"folder/note3.md",
+			"folder/note4.md",
+			"vault-folder/note5.md",
+			"vault-folder/note6.md",
+			"outside-folder/note7.md",
+			"outside-folder/note8.md",
+			"vault-folder/sub/note9.md",
+			"vault-folder/sub/note10.md",
+			"outside-folder/sub/note11.md",
+			"outside-folder/sub/note12.md",
+		]);
+
+		const vault = {
+			getMarkdownFiles: jest
+				.fn()
+				.mockReturnValue(vaultFiles.map((path) => ({ path }) as TFile)),
+		} as unknown as Vault;
+
+		const metadataCache = {
+			getCache: jest.fn().mockReturnValue({ frontmatter: {} }),
+		} as unknown as MetadataCache;
+
+		it("includes all markdown files when vaultPath is '/'", async () => {
+			publisher = new Publisher(
+				{} as App,
+				{} as QuartzSyncer,
+				vault,
+				metadataCache,
+				{
+					vaultPath: "/",
+					allNotesPublishableByDefault: true,
+				} as QuartzSyncerSettings,
+				{} as DataStore,
+			);
+			const result = await publisher.getFilesMarkedForPublishing();
+
+			expect(result.notes.length).toBe(12);
+
+			expect(
+				new Set(result.notes.map((pFile) => pFile.file.path)),
+			).toEqual(new Set(vaultFiles));
+		});
+
+		it("includes only files inside vaultPath when vaultPath is not '/'", async () => {
+			publisher = new Publisher(
+				{} as App,
+				{} as QuartzSyncer,
+				vault,
+				metadataCache,
+				{
+					vaultPath: "vault-folder/",
+					allNotesPublishableByDefault: true,
+				} as QuartzSyncerSettings,
+				{} as DataStore,
+			);
+			const result = await publisher.getFilesMarkedForPublishing();
+
+			expect(result.notes.length).toBe(4);
+
+			expect(
+				new Set(result.notes.map((pFile) => pFile.file.path)),
+			).toEqual(
+				new Set([
+					"vault-folder/note5.md",
+					"vault-folder/note6.md",
+					"vault-folder/sub/note9.md",
+					"vault-folder/sub/note10.md",
+				]),
+			);
+		});
+	});
+});

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -86,14 +86,16 @@ export default class Publisher {
 	 * @returns A promise that resolves to an object containing notes and blobs to be published.
 	 */
 	async getFilesMarkedForPublishing(): Promise<MarkedForPublishing> {
-		const files = this.vault.getMarkdownFiles();
+		const vaultIsRoot = this.settings.vaultPath == "/";
 
 		// Only include files that are within the vaultPath
-		if (this.settings.vaultPath !== "/") {
-			files.filter((file) => {
-				return file.path.startsWith(this.settings.vaultPath);
-			});
-		}
+		const files = this.vault
+			.getMarkdownFiles()
+			.filter(
+				(file: TFile) =>
+					vaultIsRoot ||
+					file.path.startsWith(this.settings.vaultPath),
+			);
 
 		const notesToPublish: PublishFile[] = [];
 		const blobsToPublish: Set<string> = new Set();


### PR DESCRIPTION
closes #85 

- Add unit test to test `Vault root folder name` setting.
- Fix #85 and filter files based on `vaultPath` again