### PR TITLE
feat: improve git upgrade handlers

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,13 +2,25 @@
 title: Roadmap and Changelog
 description: Changelog and feature roadmap for Quartz Syncer.
 created: 2025-05-16T12:59:31Z+0200
-modified: 2026-06-02T19:09:30Z+0200
+modified: 2026-06-08T15:17:47Z+0200
 publish: true
 ---
 
 ## Upcoming
 
 ## Releases
+
+### Version 1.18.0
+
+- Significantly improved Quartz upgrade reliability with smart conflict resolution.
+	- Upgrades now automatically succeed when the user has only modified dedicated user files (`quartz.config.yaml`, `quartz.lock.json`, `quartz.ts`, `quartz/styles/custom.scss`, `content/`, `.github/`, `quartz/static/`, and `quartz/styles/syncer/`).
+	- Framework files (everything else) automatically accept upstream changes during upgrade.
+	- User-owned files are preserved across upgrades via snapshot and restore, even if upstream cleanly modified them.
+	- If the user has modified framework files, the upgrade fails with a specific list of which files were modified, instead of a generic merge conflict error.
+	- `quartz.config.default.yaml` is automatically accepted from upstream without blocking the upgrade.
+- Removed unnecessary post-merge commits when user files were not changed by upstream.
+- Updated upgrade notification to reference the in-app Upgrade button instead of `npx quartz upgrade`.
+	- `npx quartz upgrade` is now only recommended as a fallback when the in-app upgrade fails.
 
 ### Version 1.17.3
 

--- a/docs/Guides/CLI.md
+++ b/docs/Guides/CLI.md
@@ -2,7 +2,7 @@
 title: CLI
 description: Automate Quartz Syncer workflows from the terminal using the Obsidian CLI.
 created: 2026-04-01T00:00:00Z+0200
-modified: 2026-04-01T17:15:10Z+0200
+modified: 2026-06-08T15:22:53Z+0200
 publish: true
 tags: [guides]
 ---
@@ -168,9 +168,11 @@ obsidian quartz-syncer:upgrade dry-run format=json
 | `dry-run` | Check for available updates without applying them. |
 | `format` | Output format: `json` or `text` (default). |
 
-> [!WARNING] Merge conflicts
+> [!INFO] Smart conflict resolution
 >
-> If the upgrade encounters merge conflicts (other than `quartz.lock.json`, which is auto-resolved), the command will fail and list the conflicting files. Resolve them manually in your repository.
+> Quartz Syncer automatically resolves most upgrade conflicts. User files (`quartz.config.yaml`, `quartz.lock.json`, `quartz.ts`, `quartz/styles/custom.scss`, `content/`, `.github/`, `quartz/static/`, and `quartz/styles/syncer/`) are preserved, while framework files accept upstream changes.
+>
+> If you have modified framework files (e.g., `package.json`, files in `quartz/components/`), the upgrade will fail and list which files were modified. In that case, run `npx quartz upgrade` in your repository to resolve conflicts manually.
 
 ### `quartz-syncer:version`
 

--- a/docs/Troubleshooting/Quartz.md
+++ b/docs/Troubleshooting/Quartz.md
@@ -2,7 +2,7 @@
 title: Quartz
 description: Troubleshooting issues related to Quartz.
 created: 2025-05-05T00:00:00Z+0200
-modified: 2026-04-01T17:15:09Z+0200
+modified: 2026-06-08T15:23:03Z+0200
 publish: true
 tags: [quartz]
 ---
@@ -62,6 +62,32 @@ The same flag works for `plugin add`:
 ```bash
 npx quartz plugin add github:quartz-community/some-plugin -c 1
 ```
+
+## Upgrade fails with "Cannot auto-upgrade: you have modified framework files"
+
+This means you've changed files that are part of the Quartz framework itself (e.g., `package.json`, files in `quartz/components/`, `quartz/plugins/`). Quartz Syncer cannot safely merge upstream changes into these files because your modifications would be overwritten.
+
+**What to do:**
+
+1. The error message lists exactly which files were modified. Review the list to confirm they are intentional changes.
+2. Run `npx quartz upgrade` in your Quartz repository to resolve the conflicts manually using git's standard merge tools.
+
+**What are "framework files"?**
+
+Quartz Syncer distinguishes between files you are expected to customize and files that belong to the Quartz framework:
+
+| Your files (preserved during upgrade) | Framework files (updated from upstream) |
+|---|---|
+| `quartz.config.yaml` | `package.json` |
+| `quartz.lock.json` | `tsconfig.json` |
+| `quartz.ts` | `quartz/components/` |
+| `quartz/styles/custom.scss` | `quartz/plugins/` |
+| `quartz/styles/syncer/` | `quartz/cli/` |
+| `quartz/static/` (icon, OG image) | `quartz/styles/` (except `custom.scss` and `syncer/`) |
+| `content/` | `quartz/processors/` |
+| `.github/` | Everything else in `quartz/` |
+
+If you need to modify framework files for your setup, use `npx quartz upgrade` instead of the in-app upgrade to handle merge conflicts manually.
 
 ## I have a different issue not listed here
 

--- a/src/cli/handlers/upgradeHandler.test.ts
+++ b/src/cli/handlers/upgradeHandler.test.ts
@@ -199,4 +199,41 @@ describe("upgradeHandler", () => {
 		expect(result).toBe("Error: Git remote URL is not configured.");
 		expect(RepositoryConnection).not.toHaveBeenCalled();
 	});
+
+	it("surfaces framework modification error from upgrade", async () => {
+		mockUpgradeFromUpstream.mockRejectedValue(
+			new Error(
+				"Cannot auto-upgrade: you have modified framework files that would " +
+					"conflict with upstream changes:\n  - package.json\n" +
+					"Run `npx quartz upgrade` manually to resolve these conflicts.",
+			),
+		);
+
+		const result = await handler({
+			force: "true",
+			format: "json",
+		} as CliData);
+
+		const parsed = JSON.parse(result);
+
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toContain("Cannot auto-upgrade");
+		expect(parsed.error).toContain("package.json");
+	});
+
+	it("surfaces merge conflict error from upgrade", async () => {
+		mockUpgradeFromUpstream.mockRejectedValue(
+			new Error("Merge conflicts in: quartz/build.ts, quartz/cli.ts"),
+		);
+
+		const result = await handler({
+			force: "true",
+			format: "json",
+		} as CliData);
+
+		const parsed = JSON.parse(result);
+
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toContain("Merge conflicts in:");
+	});
 });

--- a/src/quartz/QuartzUpgradeService.test.ts
+++ b/src/quartz/QuartzUpgradeService.test.ts
@@ -187,3 +187,90 @@ describe("QuartzUpgradeService", () => {
 		assert.strictEqual(status.latestUpstreamSha, "abc1234");
 	});
 });
+
+describe("QuartzUpgradeService.performUpgrade", () => {
+	it("returns success on clean merge", async () => {
+		const mockRepo = {
+			hasCommitInHistory: async () => true,
+			upgradeFromUpstream: async () => ({
+				oid: "abc123",
+				alreadyMerged: false,
+			}),
+		} as unknown as RepositoryConnection;
+
+		const service = new QuartzUpgradeService(mockRepo);
+		const result = await service.performUpgrade();
+
+		assert.strictEqual(result.success, true);
+		assert.strictEqual(result.oid, "abc123");
+		assert.strictEqual(result.alreadyMerged, false);
+	});
+
+	it("returns success when already merged", async () => {
+		const mockRepo = {
+			hasCommitInHistory: async () => true,
+			upgradeFromUpstream: async () => ({
+				oid: "abc123",
+				alreadyMerged: true,
+			}),
+		} as unknown as RepositoryConnection;
+
+		const service = new QuartzUpgradeService(mockRepo);
+		const result = await service.performUpgrade();
+
+		assert.strictEqual(result.success, true);
+		assert.strictEqual(result.alreadyMerged, true);
+	});
+
+	it("detects 'Cannot auto-upgrade' as conflict error", async () => {
+		const mockRepo = {
+			hasCommitInHistory: async () => true,
+			upgradeFromUpstream: async () => {
+				throw new Error(
+					"Cannot auto-upgrade: you have modified framework files",
+				);
+			},
+		} as unknown as RepositoryConnection;
+
+		const service = new QuartzUpgradeService(mockRepo);
+		const result = await service.performUpgrade();
+
+		assert.strictEqual(result.success, false);
+		assert.ok(result.error?.includes("Cannot auto-upgrade"));
+		assert.ok(result.error?.includes("npx quartz upgrade"));
+	});
+
+	it("detects 'Merge conflicts in' as conflict error", async () => {
+		const mockRepo = {
+			hasCommitInHistory: async () => true,
+			upgradeFromUpstream: async () => {
+				throw new Error(
+					"Merge conflicts in: package.json, tsconfig.json",
+				);
+			},
+		} as unknown as RepositoryConnection;
+
+		const service = new QuartzUpgradeService(mockRepo);
+		const result = await service.performUpgrade();
+
+		assert.strictEqual(result.success, false);
+		assert.ok(result.error?.includes("Merge conflicts in:"));
+		assert.ok(result.error?.includes("npx quartz upgrade"));
+	});
+
+	it("treats non-conflict errors as generic failures", async () => {
+		const mockRepo = {
+			hasCommitInHistory: async () => true,
+			upgradeFromUpstream: async () => {
+				throw new Error("Network timeout");
+			},
+		} as unknown as RepositoryConnection;
+
+		const service = new QuartzUpgradeService(mockRepo);
+		const result = await service.performUpgrade();
+
+		assert.strictEqual(result.success, false);
+		assert.ok(result.error?.includes("Network timeout"));
+		assert.ok(!result.error?.includes("npx quartz upgrade"));
+	});
+});

--- a/src/quartz/QuartzUpgradeService.ts
+++ b/src/quartz/QuartzUpgradeService.ts
@@ -153,6 +153,7 @@ export class QuartzUpgradeService {
 
 			const isConflict =
 				message.includes("Merge conflicts in:") ||
+				message.includes("Cannot auto-upgrade:") ||
 				message.includes("MergeNotSupportedError") ||
 				message.includes("MergeConflictError") ||
 				message.includes("Merges with conflicts");

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -4,6 +4,11 @@ import { normalizePath, requestUrl } from "obsidian";
 import { CompiledPublishFile } from "src/publishFile/PublishFile";
 import { GitAuth, GitRemoteSettings } from "src/models/settings";
 import { removeLeadingSlash } from "src/utils/utils";
+import {
+	isPreflightExempt,
+	isUserOwnedPath,
+	USER_OWNED_FILES,
+} from "./fileOwnership";
 
 async function collectBody(
 	body: AsyncIterableIterator<Uint8Array> | undefined,
@@ -696,6 +701,137 @@ export class RepositoryConnection {
 		}
 	}
 
+	private async detectFrameworkModifications(
+		oursOid: string,
+		baseOid: string,
+	): Promise<string[]> {
+		const modified: string[] = [];
+
+		await git.walk({
+			...this.getGitConfig(),
+			trees: [git.TREE({ ref: oursOid }), git.TREE({ ref: baseOid })],
+			map: async (filepath, [ours, base]) => {
+				if (filepath === ".") return undefined;
+
+				const oursType = ours ? await ours.type() : undefined;
+				const baseType = base ? await base.type() : undefined;
+
+				if (oursType === "tree" || baseType === "tree") return filepath;
+
+				if (isPreflightExempt(filepath)) return undefined;
+
+				const oursOidVal = ours ? await ours.oid() : undefined;
+				const baseOidVal = base ? await base.oid() : undefined;
+
+				if (oursOidVal !== baseOidVal) {
+					modified.push(filepath);
+				}
+
+				return undefined;
+			},
+		});
+
+		return modified;
+	}
+
+	private async snapshotUserOwnedFiles(
+		commitOid: string,
+	): Promise<Map<string, Uint8Array>> {
+		const snapshots = new Map<string, Uint8Array>();
+
+		for (const filepath of USER_OWNED_FILES) {
+			try {
+				const { blob } = await git.readBlob({
+					...this.getGitConfig(),
+					oid: commitOid,
+					filepath,
+				});
+				snapshots.set(filepath, blob);
+			} catch {
+				// File doesn't exist in this commit — skip
+			}
+		}
+
+		return snapshots;
+	}
+
+	private async restoreUserOwnedFiles(
+		snapshots: Map<string, Uint8Array>,
+	): Promise<boolean> {
+		let restored = false;
+
+		for (const [filepath, blob] of snapshots) {
+			const fullPath = `${this.dir}/${filepath}`;
+
+			try {
+				const current = await this.getFs().promises.readFile(fullPath);
+
+				if (
+					current.length === blob.length &&
+					current.every((byte: number, i: number) => byte === blob[i])
+				) {
+					continue;
+				}
+			} catch {
+				/* file missing after merge */
+			}
+
+			await this.ensureDirectory(filepath);
+			await this.getFs().promises.writeFile(fullPath, blob);
+
+			await git.add({
+				...this.getGitConfig(),
+				filepath,
+			});
+
+			restored = true;
+		}
+
+		return restored;
+	}
+
+	private createUpgradeMergeDriver(): {
+		driver: (args: {
+			branches: string[];
+			contents: string[];
+			path: string;
+		}) => Promise<{ cleanMerge: boolean; mergedText: string }>;
+		resolutions: Map<string, "ours" | "theirs">;
+	} {
+		const resolutions = new Map<string, "ours" | "theirs">();
+
+		const driver = async ({
+			contents,
+			path,
+		}: {
+			branches: string[];
+			contents: string[];
+			path: string;
+		}) => {
+			const [_base, ours, theirs] = contents;
+
+			if (isUserOwnedPath(path)) {
+				resolutions.set(path, "ours");
+
+				console.debug(
+					`Auto-resolved conflict in ${path}: keeping ours`,
+				);
+
+				return { cleanMerge: true, mergedText: ours ?? "" };
+			}
+
+			resolutions.set(path, "theirs");
+
+			console.debug(
+				`Auto-resolved conflict in ${path}: accepting theirs`,
+			);
+
+			return { cleanMerge: true, mergedText: theirs ?? "" };
+		};
+
+		return { driver, resolutions };
+	}
+
 	async upgradeFromUpstream(
 		upstreamUrl: string,
 		upstreamBranch: string,
@@ -744,22 +880,52 @@ export class RepositoryConnection {
 		});
 
 		const mergeRef = `remotes/${remoteName}/${upstreamBranch}`;
-		const lockfilePath = "quartz.lock.json";
-
 		const mergeAuthor = RepositoryConnection.COMMIT_AUTHOR;
 
-		let lockfileBackup: Uint8Array | null = null;
+		const oursOid = await git.resolveRef({
+			...this.getGitConfig(),
+			ref: this.branch,
+		});
 
-		try {
-			const { blob } = await git.readBlob({
-				...this.getGitConfig(),
-				oid: remoteCommit,
-				filepath: lockfilePath,
-			});
-			lockfileBackup = blob;
-		} catch {
-			console.debug("No quartz.lock.json found, skipping backup");
+		const theirsOid = await git.resolveRef({
+			...this.getGitConfig(),
+			ref: mergeRef,
+		});
+
+		// Phase 1: Preflight — detect framework modifications
+		const mergeBaseOids: string[] = (await git.findMergeBase({
+			...this.getGitConfig(),
+			oids: [oursOid, theirsOid],
+		})) as string[];
+
+		if (mergeBaseOids.length === 0) {
+			throw new Error(
+				"Cannot determine merge base between your repository and upstream. " +
+					"Run `npx quartz upgrade` manually.",
+			);
 		}
+
+		const baseOid = mergeBaseOids[0];
+
+		const frameworkMods = await this.detectFrameworkModifications(
+			oursOid,
+			baseOid,
+		);
+
+		if (frameworkMods.length > 0) {
+			const fileList = frameworkMods.map((f) => `  - ${f}`).join("\n");
+			throw new Error(
+				`Cannot auto-upgrade: you have modified framework files that would ` +
+					`conflict with upstream changes:\n${fileList}\n` +
+					`Run \`npx quartz upgrade\` manually to resolve these conflicts.`,
+			);
+		}
+
+		// Phase 2: Snapshot + Merge
+		const snapshots = await this.snapshotUserOwnedFiles(oursOid);
+
+		const { driver: mergeDriver, resolutions } =
+			this.createUpgradeMergeDriver();
 
 		let result: {
 			oid?: string;
@@ -771,65 +937,44 @@ export class RepositoryConnection {
 				...this.getGitConfig(),
 				ours: this.branch,
 				theirs: mergeRef,
-				abortOnConflict: true,
+				abortOnConflict: false,
+				mergeDriver,
 				author: mergeAuthor,
 			});
 		} catch (mergeError) {
-			const conflictFiles = this.throwIfNonLockfileConflicts(
-				mergeError,
-				lockfilePath,
-			);
+			const conflictFiles = this.extractConflictFiles(mergeError);
 
-			if (!lockfileBackup) {
-				throw new Error(
-					`Merge conflicts in: ${conflictFiles.join(", ")}`,
-				);
-			}
+			if (!conflictFiles) throw mergeError;
 
-			console.debug("Only quartz.lock.json conflicts, auto-resolving");
-
-			try {
-				await git.merge({
-					...this.getGitConfig(),
-					ours: this.branch,
-					theirs: mergeRef,
-					abortOnConflict: false,
-					author: mergeAuthor,
-				});
-			} catch (retryError) {
-				this.throwIfNonLockfileConflicts(retryError, lockfilePath);
-			}
-
-			const fullLockfilePath = `${this.dir}/${lockfilePath}`;
-
-			await this.getFs().promises.writeFile(
-				fullLockfilePath,
-				lockfileBackup,
-			);
-
-			await git.add({
-				...this.getGitConfig(),
-				filepath: lockfilePath,
-			});
-
-			const oursOid = await git.resolveRef({
-				...this.getGitConfig(),
-				ref: this.branch,
-			});
-
-			const theirsOid = await git.resolveRef({
-				...this.getGitConfig(),
-				ref: mergeRef,
-			});
+			await this.restoreUserOwnedFiles(snapshots);
 
 			const commitOid = await git.commit({
 				...this.getGitConfig(),
-				message: `Merge upstream/${upstreamBranch} (auto-resolved quartz.lock.json)`,
+				message: `Merge upstream/${upstreamBranch} (auto-resolved conflicts)`,
 				author: mergeAuthor,
 				parent: [oursOid, theirsOid],
 			});
 
 			result = { oid: commitOid, alreadyMerged: false };
+
+			if (resolutions.size > 0) {
+				console.debug(
+					`Auto-resolved ${resolutions.size} conflict(s):`,
+					Object.fromEntries(resolutions),
+				);
+			}
+
+			await git.checkout({
+				...this.getGitConfig(),
+				ref: this.branch,
+			});
+
+			await this.pushWithRetry();
+
+			return {
+				oid: result.oid!,
+				alreadyMerged: false,
+			};
 		}
 
 		if (result.alreadyMerged) {
@@ -837,6 +982,28 @@ export class RepositoryConnection {
 				oid: result.oid ?? remoteCommit,
 				alreadyMerged: true,
 			};
+		}
+
+		// Phase 3: Post-merge restore — even on clean merge, restore user files
+		// in case upstream cleanly modified them
+		const filesRestored = await this.restoreUserOwnedFiles(snapshots);
+
+		let finalOid = result.oid!;
+
+		if (filesRestored) {
+			finalOid = await git.commit({
+				...this.getGitConfig(),
+				message: `Merge upstream/${upstreamBranch}`,
+				author: mergeAuthor,
+				parent: [oursOid, theirsOid],
+			});
+		}
+
+		if (resolutions.size > 0) {
+			console.debug(
+				`Auto-resolved ${resolutions.size} conflict(s):`,
+				Object.fromEntries(resolutions),
+			);
 		}
 
 		await git.checkout({
@@ -847,7 +1014,7 @@ export class RepositoryConnection {
 		await this.pushWithRetry();
 
 		return {
-			oid: result.oid!,
+			oid: finalOid,
 			alreadyMerged: false,
 		};
 	}
@@ -918,25 +1085,6 @@ export class RepositoryConnection {
 			...this.getGitConfig(),
 			ref: this.branch,
 		});
-	}
-
-	private throwIfNonLockfileConflicts(
-		error: unknown,
-		lockfilePath: string,
-	): string[] {
-		const conflictFiles = this.extractConflictFiles(error);
-
-		if (!conflictFiles) throw error;
-
-		const nonLockfileConflicts = conflictFiles.filter(
-			(f: string) => f !== lockfilePath,
-		);
-
-		if (nonLockfileConflicts.length > 0) {
-			throw new Error(`Merge conflicts in: ${conflictFiles.join(", ")}`);
-		}
-
-		return conflictFiles;
 	}
 
 	async deleteFiles(

--- a/src/repositoryConnection/fileOwnership.test.ts
+++ b/src/repositoryConnection/fileOwnership.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert";
+import {
+	isPreflightExempt,
+	isUserOwnedPath,
+	USER_OWNED_FILES,
+} from "./fileOwnership";
+
+describe("isUserOwnedPath", () => {
+	it.each([
+		"quartz.config.yaml",
+		"quartz.lock.json",
+		"quartz.ts",
+		"quartz/styles/custom.scss",
+	])("classifies %s as user-owned", (filepath) => {
+		assert.strictEqual(isUserOwnedPath(filepath), true);
+	});
+
+	it.each([
+		"content/notes/hello.md",
+		"content/index.md",
+		"content/sub/deep/file.md",
+	])("classifies %s as user-owned (content directory)", (filepath) => {
+		assert.strictEqual(isUserOwnedPath(filepath), true);
+	});
+
+	it.each([
+		".github/workflows/deploy.yaml",
+		".github/workflows/deploy.yml",
+		".github/CNAME",
+	])("classifies %s as user-owned (.github directory)", (filepath) => {
+		assert.strictEqual(isUserOwnedPath(filepath), true);
+	});
+
+	it.each(["quartz/static/icon.png", "quartz/static/og-image.png"])(
+		"classifies %s as user-owned (static assets)",
+		(filepath) => {
+			assert.strictEqual(isUserOwnedPath(filepath), true);
+		},
+	);
+
+	it.each([
+		"quartz/styles/syncer/_index.scss",
+		"quartz/styles/syncer/_datacore.scss",
+		"quartz/styles/syncer/_excalidraw.scss",
+		"quartz/styles/syncer/_auto-card-link.scss",
+		"quartz/styles/syncer/_fantasy-statblocks.scss",
+	])("classifies %s as user-owned (syncer styles)", (filepath) => {
+		assert.strictEqual(isUserOwnedPath(filepath), true);
+	});
+
+	it.each([
+		"package.json",
+		"tsconfig.json",
+		"quartz.config.default.yaml",
+		"quartz/components/frames/default.tsx",
+		"quartz/styles/base.scss",
+		"quartz/plugins/loader/config-loader.ts",
+		"node_modules/isomorphic-git/index.js",
+		".gitignore",
+	])("classifies %s as framework", (filepath) => {
+		assert.strictEqual(isUserOwnedPath(filepath), false);
+	});
+
+	it("classifies empty string as framework", () => {
+		assert.strictEqual(isUserOwnedPath(""), false);
+	});
+
+	it("does not match 'content' without trailing slash", () => {
+		assert.strictEqual(isUserOwnedPath("content"), false);
+	});
+
+	it("does not match paths that start with 'content' but aren't in the directory", () => {
+		assert.strictEqual(isUserOwnedPath("content-index.json"), false);
+	});
+});
+
+describe("USER_OWNED_FILES", () => {
+	it("contains exactly 4 entries", () => {
+		assert.strictEqual(USER_OWNED_FILES.size, 4);
+	});
+});
+
+describe("isPreflightExempt", () => {
+	it("exempts user-owned files", () => {
+		assert.strictEqual(isPreflightExempt("quartz.config.yaml"), true);
+		assert.strictEqual(isPreflightExempt("content/note.md"), true);
+	});
+
+	it("exempts quartz.config.default.yaml (safe to overwrite)", () => {
+		assert.strictEqual(
+			isPreflightExempt("quartz.config.default.yaml"),
+			true,
+		);
+	});
+
+	it("does not exempt framework files", () => {
+		assert.strictEqual(isPreflightExempt("package.json"), false);
+		assert.strictEqual(isPreflightExempt("tsconfig.json"), false);
+	});
+});

--- a/src/repositoryConnection/fileOwnership.ts
+++ b/src/repositoryConnection/fileOwnership.ts
@@ -1,0 +1,47 @@
+/**
+ * File ownership classification for Quartz upgrade merge conflict resolution.
+ *
+ * During upstream upgrades, files are classified as either "user-owned" (preserve
+ * the user's version) or "framework" (accept upstream changes). This distinction
+ * drives the preflight gate, merge driver, and post-merge restore phases.
+ *
+ * Note: QUARTZ_SYNCER_V5.md lists quartz.ts as upstream-owned, but users can
+ * customize it in practice. The classification below reflects actual usage.
+ */
+
+export const USER_OWNED_FILES = new Set([
+	"quartz.config.yaml",
+	"quartz.lock.json",
+	"quartz.ts",
+	"quartz/styles/custom.scss",
+]);
+
+const USER_OWNED_PREFIXES = [
+	"content/",
+	".github/",
+	"quartz/static/",
+	"quartz/styles/syncer/",
+];
+
+const SAFE_TO_OVERWRITE_FILES = new Set(["quartz.config.default.yaml"]);
+
+/**
+ * Returns true if the given filepath belongs to the user (should be preserved
+ * during upstream merges), false if it's a framework file (should accept
+ * upstream changes).
+ */
+export function isUserOwnedPath(filepath: string): boolean {
+	if (USER_OWNED_FILES.has(filepath)) return true;
+
+	return USER_OWNED_PREFIXES.some((prefix) => filepath.startsWith(prefix));
+}
+
+/**
+ * Returns true if the filepath should be excluded from the preflight
+ * framework-modification check. These are files that may diverge between
+ * the user's fork and the merge base, but are safe to overwrite with
+ * upstream's version (they're not user-customized, just stale).
+ */
+export function isPreflightExempt(filepath: string): boolean {
+	return isUserOwnedPath(filepath) || SAFE_TO_OVERWRITE_FILES.has(filepath);
+}

--- a/src/repositoryConnection/upgradeConflictResolution.test.ts
+++ b/src/repositoryConnection/upgradeConflictResolution.test.ts
@@ -1,0 +1,677 @@
+import assert from "node:assert";
+import { RepositoryConnection } from "./RepositoryConnection";
+
+const mockFetch = jest.fn();
+const mockResolveRef = jest.fn();
+const mockCheckout = jest.fn();
+const mockBranch = jest.fn();
+const mockListRemotes = jest.fn();
+const mockDeleteRemote = jest.fn();
+const mockAddRemote = jest.fn();
+const mockMerge = jest.fn();
+const mockFindMergeBase = jest.fn();
+const mockWalk = jest.fn();
+const mockReadBlob = jest.fn();
+const mockAdd = jest.fn();
+const mockCommit = jest.fn();
+const mockPush = jest.fn();
+const mockTREE = jest.fn();
+const mockClone = jest.fn();
+const mockReadCommit = jest.fn();
+const mockReadTree = jest.fn();
+const mockRemove = jest.fn();
+
+jest.mock("isomorphic-git", () => ({
+	__esModule: true,
+	default: {
+		fetch: (...args: unknown[]) => mockFetch(...args),
+		resolveRef: (...args: unknown[]) => mockResolveRef(...args),
+		checkout: (...args: unknown[]) => mockCheckout(...args),
+		branch: (...args: unknown[]) => mockBranch(...args),
+		listRemotes: (...args: unknown[]) => mockListRemotes(...args),
+		deleteRemote: (...args: unknown[]) => mockDeleteRemote(...args),
+		addRemote: (...args: unknown[]) => mockAddRemote(...args),
+		merge: (...args: unknown[]) => mockMerge(...args),
+		findMergeBase: (...args: unknown[]) => mockFindMergeBase(...args),
+		walk: (...args: unknown[]) => mockWalk(...args),
+		readBlob: (...args: unknown[]) => mockReadBlob(...args),
+		add: (...args: unknown[]) => mockAdd(...args),
+		commit: (...args: unknown[]) => mockCommit(...args),
+		push: (...args: unknown[]) => mockPush(...args),
+		clone: (...args: unknown[]) => mockClone(...args),
+		readCommit: (...args: unknown[]) => mockReadCommit(...args),
+		readTree: (...args: unknown[]) => mockReadTree(...args),
+		remove: (...args: unknown[]) => mockRemove(...args),
+		TREE: (...args: unknown[]) => mockTREE(...args),
+	},
+	TREE: (...args: unknown[]) => mockTREE(...args),
+}));
+
+jest.mock("@isomorphic-git/lightning-fs", () => {
+	return jest.fn().mockImplementation(() => ({
+		promises: {
+			mkdir: jest.fn().mockResolvedValue(undefined),
+			writeFile: jest.fn().mockResolvedValue(undefined),
+			readFile: jest.fn().mockResolvedValue(new Uint8Array()),
+			unlink: jest.fn().mockResolvedValue(undefined),
+			stat: jest.fn().mockResolvedValue({ type: "dir" }),
+		},
+	}));
+});
+
+jest.mock("obsidian", () => ({
+	normalizePath: (p: string) => p.replace(/\\/g, "/").replace(/^\//, ""),
+	requestUrl: jest.fn(),
+}));
+
+function createConnection(): RepositoryConnection {
+	return new RepositoryConnection({
+		gitSettings: {
+			remoteUrl: "https://github.com/test/repo.git",
+			branch: "main",
+			auth: { type: "none" as const },
+		},
+		contentFolder: "content",
+		vaultPath: "/",
+	});
+}
+
+function setupDefaultMocks(): void {
+	mockFetch.mockResolvedValue(undefined);
+	mockCheckout.mockResolvedValue(undefined);
+	mockBranch.mockResolvedValue(undefined);
+	mockAdd.mockResolvedValue(undefined);
+	mockPush.mockResolvedValue(undefined);
+	mockAddRemote.mockResolvedValue(undefined);
+	mockDeleteRemote.mockResolvedValue(undefined);
+	mockCommit.mockResolvedValue("commit123");
+	mockTREE.mockReturnValue({ _marker: "TREE" });
+
+	mockListRemotes.mockResolvedValue([
+		{ remote: "origin", url: "https://github.com/test/repo.git" },
+	]);
+
+	mockResolveRef.mockImplementation(
+		(opts: { ref: string }): Promise<string> => {
+			if (opts.ref === "origin/main") return Promise.resolve("ours123");
+			if (opts.ref === "main") return Promise.resolve("ours123");
+			if (opts.ref === "remotes/upstream/v5")
+				return Promise.resolve("theirs456");
+			return Promise.resolve("unknown");
+		},
+	);
+}
+
+describe("upgradeFromUpstream — conflict resolution", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		setupDefaultMocks();
+	});
+
+	it("Test 1: clean merge (no conflicts)", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		mockMerge.mockResolvedValue({
+			oid: "merge123",
+			alreadyMerged: false,
+		});
+
+		mockReadBlob.mockRejectedValue(new Error("not found"));
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, false);
+		assert.ok(result.oid);
+		assert.ok(mockMerge.mock.calls.length > 0);
+	});
+
+	it("Test 2: already merged", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		mockMerge.mockResolvedValue({
+			oid: "abc",
+			alreadyMerged: true,
+		});
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, true);
+		assert.strictEqual(mockCommit.mock.calls.length, 0);
+	});
+
+	it("Test 3: findMergeBase returns empty", async () => {
+		mockFindMergeBase.mockResolvedValue([]);
+
+		const connection = createConnection();
+
+		await assert.rejects(
+			() =>
+				connection.upgradeFromUpstream(
+					"https://github.com/jackyzha0/quartz.git",
+					"v5",
+				),
+			(error: Error) => {
+				assert.ok(
+					error.message.includes("Cannot determine merge base"),
+				);
+				return true;
+			},
+		);
+	});
+
+	it("Test 4: framework file modified by user (preflight fails)", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				await opts.map("package.json", [
+					{
+						type: async () => "blob",
+						oid: async () => "ours_pkg_oid",
+					},
+					{
+						type: async () => "blob",
+						oid: async () => "base_pkg_oid",
+					},
+				]);
+				return [];
+			},
+		);
+
+		const connection = createConnection();
+
+		await assert.rejects(
+			() =>
+				connection.upgradeFromUpstream(
+					"https://github.com/jackyzha0/quartz.git",
+					"v5",
+				),
+			(error: Error) => {
+				assert.ok(error.message.includes("Cannot auto-upgrade"));
+				assert.ok(error.message.includes("package.json"));
+				return true;
+			},
+		);
+	});
+
+	it("Test 5: multiple framework files modified (preflight fails)", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				await opts.map("package.json", [
+					{
+						type: async () => "blob",
+						oid: async () => "ours_pkg_oid",
+					},
+					{
+						type: async () => "blob",
+						oid: async () => "base_pkg_oid",
+					},
+				]);
+				await opts.map("tsconfig.json", [
+					{
+						type: async () => "blob",
+						oid: async () => "ours_ts_oid",
+					},
+					{
+						type: async () => "blob",
+						oid: async () => "base_ts_oid",
+					},
+				]);
+				return [];
+			},
+		);
+
+		const connection = createConnection();
+
+		await assert.rejects(
+			() =>
+				connection.upgradeFromUpstream(
+					"https://github.com/jackyzha0/quartz.git",
+					"v5",
+				),
+			(error: Error) => {
+				assert.ok(error.message.includes("Cannot auto-upgrade"));
+				assert.ok(error.message.includes("package.json"));
+				assert.ok(error.message.includes("tsconfig.json"));
+				return true;
+			},
+		);
+	});
+
+	it("Test 6: user-owned file conflict resolved via mergeDriver", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		mockMerge.mockImplementation(
+			async (opts: {
+				mergeDriver?: (args: {
+					branches: string[];
+					contents: string[];
+					path: string;
+				}) => Promise<{ cleanMerge: boolean; mergedText: string }>;
+			}) => {
+				if (opts.mergeDriver) {
+					await opts.mergeDriver({
+						branches: ["base", "ours", "theirs"],
+						contents: [
+							"base-content",
+							"our-config",
+							"their-config",
+						],
+						path: "quartz.config.yaml",
+					});
+				}
+				return { oid: "merge_user_owned", alreadyMerged: false };
+			},
+		);
+
+		mockReadBlob.mockImplementation(async (opts: { filepath: string }) => {
+			if (opts.filepath === "quartz.config.yaml") {
+				return {
+					blob: new TextEncoder().encode("our-config"),
+					oid: "blob_oid",
+				};
+			}
+			throw new Error("not found");
+		});
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, false);
+		assert.ok(result.oid);
+	});
+
+	it("Test 7: lockfile conflict auto-resolved", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		mockMerge.mockImplementation(
+			async (opts: {
+				mergeDriver?: (args: {
+					branches: string[];
+					contents: string[];
+					path: string;
+				}) => Promise<{ cleanMerge: boolean; mergedText: string }>;
+			}) => {
+				if (opts.mergeDriver) {
+					await opts.mergeDriver({
+						branches: ["base", "ours", "theirs"],
+						contents: ["base-lock", "our-lock", "their-lock"],
+						path: "quartz.lock.json",
+					});
+				}
+				return { oid: "merge_lockfile", alreadyMerged: false };
+			},
+		);
+
+		mockReadBlob.mockRejectedValue(new Error("not found"));
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, false);
+		assert.ok(result.oid);
+	});
+
+	it("Test 8: delete conflict handled", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		const mergeError = new Error("Merge conflict") as Error & {
+			data: { filepaths: string[] };
+		};
+		mergeError.data = {
+			filepaths: ["quartz.config.yaml", "content/notes/hello.md"],
+		};
+
+		mockMerge.mockRejectedValue(mergeError);
+
+		mockReadBlob.mockImplementation(async (opts: { filepath: string }) => {
+			if (opts.filepath === "quartz.config.yaml") {
+				return {
+					blob: new TextEncoder().encode("user-config"),
+					oid: "blob_config",
+				};
+			}
+			throw new Error("not found");
+		});
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, false);
+		assert.ok(result.oid);
+		assert.ok(mockCommit.mock.calls.length > 0);
+	});
+
+	it("Test 9: snapshot restores user files after clean merge", async () => {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+				return [];
+			},
+		);
+
+		mockMerge.mockResolvedValue({
+			oid: "merge_clean",
+			alreadyMerged: false,
+		});
+
+		const configContent = new TextEncoder().encode("user-quartz-config");
+
+		mockReadBlob.mockImplementation(async (opts: { filepath: string }) => {
+			if (opts.filepath === "quartz.config.yaml") {
+				return { blob: configContent, oid: "blob_config" };
+			}
+			if (opts.filepath === "quartz.lock.json") {
+				return {
+					blob: new TextEncoder().encode("lock-content"),
+					oid: "blob_lock",
+				};
+			}
+			throw new Error("not found");
+		});
+
+		const connection = createConnection();
+		const result = await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		assert.strictEqual(result.alreadyMerged, false);
+		assert.ok(result.oid);
+
+		const addCalls = mockAdd.mock.calls as { filepath: string }[][];
+		const restoredFiles = addCalls
+			.map((call) => call[0]?.filepath)
+			.filter(Boolean);
+		assert.ok(
+			restoredFiles.includes("quartz.config.yaml"),
+			"quartz.config.yaml should be restored after merge",
+		);
+	});
+});
+
+describe("mergeDriver behavior", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		setupDefaultMocks();
+	});
+
+	async function captureMergeDriver(): Promise<
+		(args: {
+			branches: string[];
+			contents: string[];
+			path: string;
+		}) => Promise<{ cleanMerge: boolean; mergedText: string }>
+	> {
+		mockFindMergeBase.mockResolvedValue(["base123"]);
+
+		mockWalk.mockImplementation(
+			async (opts: {
+				map: (
+					filepath: string,
+					entries: (null | {
+						type: () => Promise<string>;
+						oid: () => Promise<string>;
+					})[],
+				) => Promise<string | undefined>;
+			}) => {
+				await opts.map(".", [null, null]);
+
+				return [];
+			},
+		);
+
+		mockReadBlob.mockRejectedValue(new Error("not found"));
+
+		let capturedDriver: (args: {
+			branches: string[];
+			contents: string[];
+			path: string;
+		}) => Promise<{ cleanMerge: boolean; mergedText: string }>;
+
+		mockMerge.mockImplementation(
+			(opts: { mergeDriver: typeof capturedDriver }) => {
+				capturedDriver = opts.mergeDriver;
+
+				return Promise.resolve({
+					oid: "merge123",
+					alreadyMerged: false,
+				});
+			},
+		);
+
+		const connection = createConnection();
+		await connection.upgradeFromUpstream(
+			"https://github.com/jackyzha0/quartz.git",
+			"v5",
+		);
+
+		return capturedDriver!;
+	}
+
+	it("returns ours for user-owned files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base content", "our content", "their content"],
+			path: "quartz.config.yaml",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "our content");
+	});
+
+	it("returns theirs for framework files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base content", "our content", "their content"],
+			path: "package.json",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "their content");
+	});
+
+	it("returns ours for content directory files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", "our note", "their note"],
+			path: "content/notes/hello.md",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "our note");
+	});
+
+	it("returns ours for .github files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", "our workflow", "their workflow"],
+			path: ".github/workflows/deploy.yaml",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "our workflow");
+	});
+
+	it("returns ours for syncer style files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", "our scss", "their scss"],
+			path: "quartz/styles/syncer/_datacore.scss",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "our scss");
+	});
+
+	it("returns ours for static asset files", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", "our icon", "their icon"],
+			path: "quartz/static/icon.png",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "our icon");
+	});
+
+	it("handles undefined ours gracefully", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", undefined as unknown as string, "their content"],
+			path: "quartz.lock.json",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "");
+	});
+
+	it("handles undefined theirs gracefully", async () => {
+		const driver = await captureMergeDriver();
+
+		const result = await driver({
+			branches: ["base", "ours", "theirs"],
+			contents: ["base", "our content", undefined as unknown as string],
+			path: "tsconfig.json",
+		});
+
+		assert.strictEqual(result.cleanMerge, true);
+		assert.strictEqual(result.mergedText, "");
+	});
+});

--- a/src/views/SettingsView/Views/QuartzV5SettingsTab.ts
+++ b/src/views/SettingsView/Views/QuartzV5SettingsTab.ts
@@ -861,8 +861,8 @@ export class QuartzV5Page extends SettingPage {
 			if (hasUpdate) {
 				new Notice(
 					useCommitStrategy
-						? "New upstream Quartz commits available. Run `npx quartz upgrade` to upgrade."
-						: "A Quartz upgrade is available. Run `npx quartz upgrade` to upgrade.",
+						? "New upstream Quartz commits available. Use the Upgrade button in settings to upgrade."
+						: "A Quartz upgrade is available. Use the Upgrade button in settings to upgrade.",
 				);
 			} else if (!this.cachedUpgradeStatus.error) {
 				new Notice("Quartz is up to date.");


### PR DESCRIPTION
- Significantly improved Quartz upgrade reliability with smart conflict resolution.
	- Upgrades now automatically succeed when the user has only modified dedicated user files (`quartz.config.yaml`, `quartz.lock.json`, `quartz.ts`, `quartz/styles/custom.scss`, `content/`, `.github/`, `quartz/static/`, and `quartz/styles/syncer/`).
	- Framework files (everything else) automatically accept upstream changes during upgrade.
	- User-owned files are preserved across upgrades via snapshot and restore, even if upstream cleanly modified them.
	- If the user has modified framework files, the upgrade fails with a specific list of which files were modified, instead of a generic merge conflict error.
	- `quartz.config.default.yaml` is automatically accepted from upstream without blocking the upgrade.
- Removed unnecessary post-merge commits when user files were not changed by upstream.
- Updated upgrade notification to reference the in-app Upgrade button instead of `npx quartz upgrade`.
	- `npx quartz upgrade` is now only recommended as a fallback when the in-app upgrade fails.
