### PR TITLE
fix: commit linked svg files

### DIFF
--- a/src/compiler/SyncerPageCompiler.ts
+++ b/src/compiler/SyncerPageCompiler.ts
@@ -308,6 +308,7 @@ export class SyncerPageCompiler {
 		"wav",
 		"ogg",
 		"pdf",
+		"svg",
 	]);
 
 	/**


### PR DESCRIPTION
Solves #131 → The plugin now correctly bundles the linked .svg files in the commit, instead of filtering them all out.